### PR TITLE
Fix: Strict Standards: Declaration of Dura_Class_Xml::asXML() should …

### DIFF
--- a/trust_path/class/xml.php
+++ b/trust_path/class/xml.php
@@ -2,7 +2,7 @@
 
 class Dura_Class_Xml extends SimpleXMLElement
 {
-    public function asXML()
+    public function asXML($filename = null)
     {
         $string = parent::asXML();
         $this->_creanupXML($string);


### PR DESCRIPTION
Fix this error message:

Strict Standards: Declaration of Dura_Class_Xml::asXML() should be compatible with SimpleXMLElement::asXML($filename = NULL)
